### PR TITLE
feat: increase integration tests with `concurrently` and `async-retry`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@swc/jest": "^0.2.39",
+        "@types/async-retry": "^1.4.9",
         "@types/bcryptjs": "^2.4.6",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.13",
@@ -30,8 +31,10 @@
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.3.0",
         "@typescript-eslint/parser": "^8.3.0",
+        "async-retry": "^1.3.3",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
+        "concurrently": "^9.2.1",
         "dotenv": "^16.4.5",
         "eslint": "^9.9.1",
         "eslint-config": "^0.1.0",
@@ -1841,6 +1844,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/async-retry": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.9.tgz",
+      "integrity": "sha512-s1ciZQJzRh3708X/m3vPExr5KJlzlZJvXsKpbtE2luqNcbROr64qU+3KpJsYHqWMeaxI839OvXf9PrUSw1Xtyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2065,6 +2078,13 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2561,6 +2581,16 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3157,6 +3187,47 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -7004,6 +7075,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7054,6 +7135,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -7209,6 +7300,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -7609,6 +7713,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "npm run services:up && npm run wait-for-postgres && npm run migration:up && nodemon --watch src src/server.ts",
     "test": "jest",
-    "test:integration": "jest -- integration",
+    "test:integration": "npm run services:up && concurrently -n nodemon,jest --hide nodemon -k -s command-jest \"nodemon --watch src src/server\" \"jest --runInBand\"",
     "services:up": "docker compose -f src/infra/compose.dev.yaml --env-file .env.development up -d",
     "services:start": "docker compose -f src/infra/compose.dev.yaml start",
     "services:down": "docker compose -f src/infra/compose.dev.yaml down",
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@swc/jest": "^0.2.39",
+    "@types/async-retry": "^1.4.9",
     "@types/bcryptjs": "^2.4.6",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.13",
@@ -35,8 +36,10 @@
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
+    "async-retry": "^1.3.3",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^2.4.3",
+    "concurrently": "^9.2.1",
     "dotenv": "^16.4.5",
     "eslint": "^9.9.1",
     "eslint-config": "^0.1.0",

--- a/test/integration/api/login/post.test.ts
+++ b/test/integration/api/login/post.test.ts
@@ -1,15 +1,17 @@
 import prisma from "../../../../src/utils/prismaClient";
 import jwt from "jsonwebtoken";
 import { hash } from "bcryptjs";
+import orchestrator from "../../orchestrator";
 
 describe("POST on /login", () => {
 
     beforeAll(async () => {
+        await orchestrator.waitForAllServices();
         await prisma.workout.deleteMany()
         await prisma.user.deleteMany()
 
         const hashedPassword = await hash("senhasecreta", 10);
-        
+
         const user = await prisma.user.create({
             data: {
                 name: "Pedro",
@@ -48,13 +50,13 @@ describe("POST on /login", () => {
             },
             body: JSON.stringify(loginData)
         })
-        return result; 
+        return result;
     }
 
     test("Should return a status 200 on success", async () => {
         const result = await login(loginData)
         expect(result.status).toBe(200)
-        
+
         const responseBody = await result.json()
         expect(responseBody).toHaveProperty('token')
         expect(responseBody.token).toBeDefined()
@@ -65,39 +67,39 @@ describe("POST on /login", () => {
     })
 
     test.each(requiredFields)("Should return a status 400 if %s is not sent", async (field) => {
-        const {[field]: ignored, ...invalidLoginData} = loginData
+        const { [field]: ignored, ...invalidLoginData } = loginData
         const result = await login(invalidLoginData)
         expect(result.status).toBe(400)
     })
-    
+
     test("Should return a status 401 for invalid credentials", async () => {
         const invalidCredentials = {
             email: "teste@email.com",
             password: "senhaerrada"
         }
-        
+
         const result = await login(invalidCredentials)
         expect(result.status).toBe(401)
     })
-    
+
     test("Should return a status 401 for non-existent email", async () => {
         const nonExistentUser = {
             email: "naoexiste@email.com",
             password: "qualquersenha"
         }
-        
+
         const result = await login(nonExistentUser)
         expect(result.status).toBe(401)
-        
+
     })
-    
+
     test("Should return a valid JWT token structure", async () => {
         const result = await login(loginData)
         const responseBody = await result.json()
-        
+
         const tokenParts = responseBody.token.split('.')
         expect(tokenParts).toHaveLength(3)
-        
+
         expect(() => {
             jwt.verify(responseBody.token, process.env.JWT_SECRET_KEY!)
         }).not.toThrow()

--- a/test/integration/api/register/post.test.ts
+++ b/test/integration/api/register/post.test.ts
@@ -1,8 +1,12 @@
 import prisma from '../../../../src/utils/prismaClient';
-
+import orchestrator from '../../orchestrator';
 describe("POST on /register - Account creation", () => {
 
-  beforeEach(cleanUsers);
+  beforeEach(async () => {
+    await cleanUsers();
+    await orchestrator.waitForAllServices();
+
+  })
 
   async function cleanUsers() {
     {

--- a/test/integration/api/status/get.test.ts
+++ b/test/integration/api/status/get.test.ts
@@ -1,16 +1,21 @@
 import { resourceLimits } from "worker_threads"
 import prisma from "../../../../src/utils/prismaClient"
+import orchestrator from '../../orchestrator';
+
+beforeAll(async () => {
+    await orchestrator.waitForAllServices();
+})
 
 describe("GET on /status", () => {
-    
+
     async function getStatus() {
-        
+
         const status = await fetch('http://localhost:3000/api/v1/status', {
             method: 'GET'
         })
         return status
     }
-    
+
     test("should return a status 200 on success", async () => {
         const result = await getStatus();
         const convertResult = await result.json()
@@ -22,9 +27,9 @@ describe("GET on /status", () => {
         const convertResult = await result.json()
         const versionResult = convertResult.dependencies.database.version
 
-        const version = await prisma.$queryRawUnsafe<any> (
+        const version = await prisma.$queryRawUnsafe<any>(
             'SHOW server_version'
-        ) 
+        )
 
         expect(versionResult).toBe(version[0].server_version)
     })

--- a/test/integration/api/workout/delete.test.ts
+++ b/test/integration/api/workout/delete.test.ts
@@ -1,11 +1,13 @@
 import prisma from "../../../../src/utils/prismaClient";
 import jwt from 'jsonwebtoken'
+import orchestrator from '../../orchestrator';
 
 describe("DELETE on /workout", () => {
     let workoutId: string
     let token: string
 
     beforeAll(async () => {
+        await orchestrator.waitForAllServices();
         await prisma.workout.deleteMany()
         await prisma.user.deleteMany()
 
@@ -30,11 +32,11 @@ describe("DELETE on /workout", () => {
         })
 
         token = jwt.sign(
-            { 
-                userId: user.id, 
+            {
+                userId: user.id,
                 email: user.email,
-            }, 
-            process.env.JWT_SECRET_KEY || "testkey", 
+            },
+            process.env.JWT_SECRET_KEY || "testkey",
             { expiresIn: '12h' }
         );
 
@@ -67,12 +69,12 @@ describe("DELETE on /workout", () => {
     })
     test("should be return 401 if user does not have access", async () => {
         const result = await fetch(`http://localhost:3000/api/v1/workout/${workoutId}`, {
-        method: "DELETE",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer token_invalido"
-        }
-    })
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": "Bearer token_invalido"
+            }
+        })
         expect(result.status).toBe(401)
     })
 })

--- a/test/integration/api/workout/post.test.ts
+++ b/test/integration/api/workout/post.test.ts
@@ -1,11 +1,13 @@
 import prisma from "../../../../src/utils/prismaClient";
 import jwt from 'jsonwebtoken'
+import orchestrator from '../../orchestrator';
 
 describe("POST on /workout", () => {
     let userId: string
     let token: string
 
     beforeAll(async () => {
+        await orchestrator.waitForAllServices();
         await prisma.workout.deleteMany()
         await prisma.user.deleteMany()
 
@@ -23,11 +25,11 @@ describe("POST on /workout", () => {
         userId = user.id
 
         token = jwt.sign(
-            { 
-                userId: user.id, 
+            {
+                userId: user.id,
                 email: user.email,
-            }, 
-            process.env.JWT_SECRET_KEY || "testkey", 
+            },
+            process.env.JWT_SECRET_KEY || "testkey",
             { expiresIn: '12h' }
         );
         workoutRegister.userId = user.id
@@ -40,17 +42,17 @@ describe("POST on /workout", () => {
     })
 
     const workoutRegister = {
-            name: "treino 1",
-            date: new Date('2011-11-11'),
-            isCompleted: false,
-            userId: ""
+        name: "treino 1",
+        date: new Date('2011-11-11'),
+        isCompleted: false,
+        userId: ""
     }
 
     type createWorkoutPayload = {
         name: string,
         date: Date,
         isCompleted: boolean,
-        userId: string; 
+        userId: string;
     }
 
     const requiredFields: (keyof createWorkoutPayload)[] = ["userId", "name", "date"]
@@ -64,9 +66,9 @@ describe("POST on /workout", () => {
             },
             body: JSON.stringify(workout)
         })
-        return result; 
+        return result;
     }
-    
+
 
     test("Should return a status 201 on success", async () => {
         const result = await createWorkout(workoutRegister)
@@ -76,7 +78,7 @@ describe("POST on /workout", () => {
     })
 
     test.each(requiredFields)("Should return a status 400 if %s is not send", async (field) => {
-        const {[field]: ignored, ...invalidWorkout} = workoutRegister
+        const { [field]: ignored, ...invalidWorkout } = workoutRegister
         const result = await createWorkout(invalidWorkout as any)
         expect(result.status).toBe(400)
     })

--- a/test/integration/orchestrator.ts
+++ b/test/integration/orchestrator.ts
@@ -1,0 +1,21 @@
+import retry from "async-retry"
+
+async function waitForAllServices() {
+  await waitForWebServer();
+
+  async function waitForWebServer() {
+    return retry(fetchStatusPage, {
+      retries: 100,
+      maxTimeout: 1000
+    });
+
+    async function fetchStatusPage() {
+      const response = await fetch("http://localhost:3000/api/v1/status")
+      const responseJson = await response.json();
+    }
+  }
+}
+
+export default {
+  waitForAllServices
+}


### PR DESCRIPTION
# Principais mudanças:
1. Melhoria nos testes de automação usando o módulo `concurrently` para rodar o servidor web e os testes de forma concorrente.
2. Outra melhoria apresentada é com o uso do módulo `async-retry` para determinar quando os testes estarão com o ambiente disponível para serem iniciados.

----
Fontes:
[npm - concurrently](https://npm.io/package/concurrently)
[npm - async-retry](https://npm.io/package/async-retry)